### PR TITLE
csrf-token rename

### DIFF
--- a/src/make-api.js
+++ b/src/make-api.js
@@ -71,7 +71,7 @@ var module = module || undefined;
       request.open( type, path, true );
     }
     if ( csrfToken ) {
-      request.setRequestHeader( "x-csrf-token", csrfToken );
+      request.setRequestHeader( "X-CSRF-Token", csrfToken ); // express.js uses a non-standard name for csrf-token
     }
     request.setRequestHeader( "Content-Type", "application/json; charset=utf-8" );
     request.onreadystatechange = function() {


### PR DESCRIPTION
switch from "X-CSRF-Token" as meta name to the validation-passing "csrf-token"

https://bugzilla.mozilla.org/show_bug.cgi?id=930166
